### PR TITLE
call transmit_unless_ignorable on InfluxDB::Rails, not InfluxDB

### DIFF
--- a/lib/influxdb/rails/rack.rb
+++ b/lib/influxdb/rails/rack.rb
@@ -13,7 +13,7 @@ module InfluxDB
         begin
           status, headers, body = @app.call(env)
         rescue => e
-          InfluxDB.transmit_unless_ignorable(e, env)
+          InfluxDB::Rails.transmit_unless_ignorable(e, env)
           raise(e)
         ensure
           _body = []


### PR DESCRIPTION
I wasn't sure the best place to test this, since the tests path before and after this, but I noticed it in testing an app of ours.
