### PR TITLE
Lazy create and memoize InfluxDB::Rails.client

### DIFF
--- a/lib/influxdb-rails.rb
+++ b/lib/influxdb-rails.rb
@@ -19,18 +19,25 @@ module InfluxDB
       include InfluxDB::Rails::Logger
 
       attr_writer :configuration
-      attr_accessor :client
+      attr_writer :client
 
       def configure(silent = false)
         yield(configuration)
-        self.client = InfluxDB::Client.new configuration.influxdb_database,
+
+        # if we change configuration, reload the client
+        self.client = nil
+
+        InfluxDB::Logging.logger = configuration.logger unless configuration.logger.nil?
+      end
+
+      def client
+        @client ||= InfluxDB::Client.new configuration.influxdb_database,
           :username => configuration.influxdb_username,
           :password => configuration.influxdb_password,
           :hosts => configuration.influxdb_hosts,
           :port => configuration.influxdb_port,
           :async => configuration.async,
           :use_ssl => configuration.use_ssl
-        InfluxDB::Logging.logger = configuration.logger unless configuration.logger.nil?
       end
 
       def configuration


### PR DESCRIPTION
Instantiating an async InfluxDB::Client creates thread workers. With the basic
setup suggested in the README, we call the InfluxDB::Rails.configure block
twice which creates 2 client instances (which each start InfluxDB::Workers)

This also fixes #14 for people using unicorn. If we create the client (and async workers) before unicorn forks, the async workers are running in the unicorn master but not the unicorn workers. Events don't get reported until the at_exit handler runs on the unicorn master. By lazy loading the client, each unicorn worker will have async worker threads to report to influxdb.
