### PR TITLE
Record HTTP status codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ InfluxDB::Rails.configure do |config|
   # config.series_name_for_controller_runtimes = "rails.controller"
   # config.series_name_for_view_runtimes       = "rails.view"
   # config.series_name_for_db_runtimes         = "rails.db"
+  # config.series_name_for_status_codes        = "rails.status"
 end
 ```
 

--- a/lib/influxdb-rails.rb
+++ b/lib/influxdb-rails.rb
@@ -65,7 +65,6 @@ module InfluxDB
       alias_method :transmit, :report_exception
 
       def handle_action_controller_metrics(name, start, finish, id, payload)
-        timestamp = finish.utc.to_i
         controller_runtime = ((finish - start)*1000).ceil
         view_runtime = (payload[:view_runtime] || 0).ceil
         db_runtime = (payload[:db_runtime] || 0).ceil
@@ -81,6 +80,9 @@ module InfluxDB
 
           client.write_point configuration.series_name_for_db_runtimes,
             :value => db_runtime, :method => method, :server => hostname
+
+          client.write_point configuration.series_name_for_status_codes,
+            :value => payload[:status], :method => method, :server => hostname
         rescue => e
           log :error, "[InfluxDB::Rails] Unable to write points: #{e.message}"
         end

--- a/lib/influxdb/rails/configuration.rb
+++ b/lib/influxdb/rails/configuration.rb
@@ -12,6 +12,7 @@ module InfluxDB
       attr_accessor :series_name_for_controller_runtimes
       attr_accessor :series_name_for_view_runtimes
       attr_accessor :series_name_for_db_runtimes
+      attr_accessor :series_name_for_status_codes
 
       attr_accessor :application_id
       attr_accessor :application_name
@@ -49,6 +50,7 @@ module InfluxDB
         :series_name_for_controller_runtimes => "rails.controller",
         :series_name_for_view_runtimes => "rails.view",
         :series_name_for_db_runtimes => "rails.db",
+        :series_name_for_status_codes => "rails.status",
 
         :ignored_exceptions => %w{ActiveRecord::RecordNotFound
                                   ActionController::RoutingError},
@@ -91,6 +93,7 @@ module InfluxDB
         @series_name_for_controller_runtimes = DEFAULTS[:series_name_for_controller_runtimes]
         @series_name_for_view_runtimes = DEFAULTS[:series_name_for_view_runtimes]
         @series_name_for_db_runtimes = DEFAULTS[:series_name_for_db_runtimes]
+        @series_name_for_status_codes = DEFAULTS[:series_name_for_status_codes]
 
         @ignored_exceptions = DEFAULTS[:ignored_exceptions].dup
         @ignored_exception_messages = DEFAULTS[:ignored_exception_messages].dup

--- a/lib/rails/generators/influxdb/templates/initializer.rb
+++ b/lib/rails/generators/influxdb/templates/initializer.rb
@@ -8,4 +8,5 @@ InfluxDB::Rails.configure do |config|
   # config.series_name_for_controller_runtimes = "rails.controller"
   # config.series_name_for_view_runtimes       = "rails.view"
   # config.series_name_for_db_runtimes         = "rails.db"
+  # config.series_name_for_status_codes        = "rails.status"
 end

--- a/spec/integration/metrics_spec.rb
+++ b/spec/integration/metrics_spec.rb
@@ -15,9 +15,8 @@ describe "collecting metrics through ActiveSupport::Notifications", :type => :re
     end
 
     it "should result in attempts to write metrics via the client" do
-      InfluxDB::Rails.client.should_receive(:write_point).exactly(3).times
+      InfluxDB::Rails.client.should_receive(:write_point).exactly(4).times
       get "/widgets"
     end
   end
 end
-


### PR DESCRIPTION
The process action event payload includes HTTP status code. It would be nice to see a comparison of 200 vs 400 vs 500 statuses. This allows you to generate some pretty useful stats:

``` sql
select count(value) from rails.status group by value, time(10s)
```

What do you think, @beckettsean?
