### PR TITLE
Attempting an upgrade of influxdb-ruby

### DIFF
--- a/influxdb-rails.gemspec
+++ b/influxdb-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.licenses = ['MIT']
 
-  s.add_runtime_dependency 'influxdb'
+  s.add_runtime_dependency 'influxdb', '~> 0.2.0'
   s.add_runtime_dependency 'railties'
 
   s.add_development_dependency 'bundler', ['>= 1.0.0']

--- a/lib/influxdb-rails.rb
+++ b/lib/influxdb-rails.rb
@@ -73,14 +73,35 @@ module InfluxDB
         hostname = Socket.gethostname
 
         begin
-          client.write_point configuration.series_name_for_controller_runtimes,
-            :value => controller_runtime, :method => method, :server => hostname
+          client.write_point configuration.series_name_for_controller_runtimes, {
+            values: {
+              value: controller_runtime,
+            },
+            tags: {
+              method: method,
+              server: hostname,
+            },
+          }
 
-          client.write_point configuration.series_name_for_view_runtimes,
-            :value => view_runtime, :method => method, :server => hostname
+          client.write_point configuration.series_name_for_view_runtimes, {
+            values: {
+              value: view_runtime,
+            },
+            tags: {
+              method: method,
+              server: hostname,
+            },
+          }
 
-          client.write_point configuration.series_name_for_db_runtimes,
-            :value => db_runtime, :method => method, :server => hostname
+          client.write_point configuration.series_name_for_db_runtimes, {
+            values: {
+              value: db_runtime,
+            },
+            tags: {
+              method: method,
+              server: hostname,
+            },
+          }
         rescue => e
           log :error, "[InfluxDB::Rails] Unable to write points: #{e.message}"
         end


### PR DESCRIPTION
Trying to update this here to use a >= 0.2.0 influxdb-ruby version to get compatibility with InfluxDB 0.9+. I may have overlooked something, but this seems to work well for me. @beckettsean 
