### PR TITLE
Use Module#prepend instead of alias_chaining for rails exceptions

### DIFF
--- a/lib/influxdb-rails.rb
+++ b/lib/influxdb-rails.rb
@@ -140,6 +140,15 @@ module InfluxDB
         transmit_unless_ignorable(e)
         raise(e)
       end
+
+      def safely_prepend(module_name, opts = {})
+        return if opts[:to].nil? || opts[:from].nil?
+        if opts[:to].respond_to?(:prepend, true)
+          opts[:to].send(:prepend, opts[:from].const_get(module_name))
+        else
+          opts[:to].send(:include, opts[:from].const_get("Old" + module_name))
+        end
+      end
     end
   end
 end

--- a/lib/influxdb/rails/middleware/hijack_render_exception.rb
+++ b/lib/influxdb/rails/middleware/hijack_render_exception.rb
@@ -2,6 +2,17 @@ module InfluxDB
   module Rails
     module Middleware
       module HijackRenderException
+        def render_exception(env, e)
+          controller = env["action_controller.instance"]
+          request_data = controller.try(:influxdb_request_data) || {}
+          unless InfluxDB::Rails.configuration.ignore_user_agent?(request_data[:user_agent])
+            InfluxDB::Rails.report_exception_unless_ignorable(e, request_data)
+          end
+          super
+        end
+      end
+
+      module OldHijackRenderException
         def self.included(base)
           base.send(:alias_method_chain, :render_exception, :influxdb)
         end
@@ -18,4 +29,3 @@ module InfluxDB
     end
   end
 end
-

--- a/lib/influxdb/rails/railtie.rb
+++ b/lib/influxdb/rails/railtie.rb
@@ -27,11 +27,17 @@ module InfluxDB
 
         if defined?(::ActionDispatch::DebugExceptions)
           require 'influxdb/rails/middleware/hijack_render_exception'
-          ::ActionDispatch::DebugExceptions.send(:include, InfluxDB::Rails::Middleware::HijackRenderException)
+          exceptions_class = ::ActionDispatch::DebugExceptions
         elsif defined?(::ActionDispatch::ShowExceptions)
           require 'influxdb/rails/middleware/hijack_render_exception'
-          ::ActionDispatch::ShowExceptions.send(:include, InfluxDB::Rails::Middleware::HijackRenderException)
+          exceptions_class = ::ActionDispatch::ShowExceptions
         end
+
+        InfluxDB::Rails.safely_prepend(
+          "HijackRenderException",
+          :from => InfluxDB::Rails::Middleware,
+          :to => exceptions_class
+        )
 
         if defined?(ActiveSupport::Notifications)
           ActiveSupport::Notifications.subscribe "process_action.action_controller" do |name, start, finish, id, payload|


### PR DESCRIPTION
Currently [alias chaining](http://stackoverflow.com/questions/3695839/ruby-on-rails-alias-method-chain-what-exactly-does-it-do) is used by this gem to tie in to exceptions. This method is now deprecated and it is suggested to use `Module#prepend`. 

This is especially an issue because if another gem Module#prepends onto the same method that is being alias chained it causes an infinite loop and a stack level too deep error. This behavior is talked about [here](https://bugs.ruby-lang.org/issues/11120). I was experiencing this exact issue with [sentry-raven](https://github.com/getsentry/raven-ruby) and based my solution on the one used by sentry-raven

This fix should be backwards compatible with any ruby versions that don't support Module#prepend