### PR TITLE
Update influxdb-ruby version to 0.5.0

### DIFF
--- a/influxdb-rails.gemspec
+++ b/influxdb-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.licenses = ['MIT']
 
-  s.add_runtime_dependency 'influxdb', '~> 0.4.0'
+  s.add_runtime_dependency 'influxdb', '~> 0.5.0'
   s.add_runtime_dependency 'railties', '> 3'
 
   s.add_development_dependency 'bundler', ['>= 1.0.0']


### PR DESCRIPTION
I think it would be cool if you merge it so far as influxdb-rails gem uses async mode by default and you have had [https://github.com/influxdata/influxdb-ruby/pull/202](url) merged.