### PR TITLE
Allow pass :open_timeout, :read_timeout and :max_delay config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ InfluxDB::Rails.configure do |config|
   config.influxdb_hosts    = ["localhost"]
   config.influxdb_port     = 8086
 
+  # config.retry = false
+  # config.async = false
+  # config.open_timeout = 5
+  # config.read_timeout = 30
+  # config.max_delay = 300
+
   # config.series_name_for_controller_runtimes = "rails.controller"
   # config.series_name_for_view_runtimes       = "rails.view"
   # config.series_name_for_db_runtimes         = "rails.db"

--- a/lib/influxdb-rails.rb
+++ b/lib/influxdb-rails.rb
@@ -38,7 +38,10 @@ module InfluxDB
           :port => configuration.influxdb_port,
           :async => configuration.async,
           :use_ssl => configuration.use_ssl,
-          :retry => configuration.retry
+          :retry => configuration.retry,
+          :open_timeout => configuration.open_timeout,
+          :read_timeout => configuration.read_timeout,
+          :max_delay => configuration.max_delay
       end
 
       def configuration

--- a/lib/influxdb/rails/configuration.rb
+++ b/lib/influxdb/rails/configuration.rb
@@ -9,6 +9,9 @@ module InfluxDB
       attr_accessor :async
       attr_accessor :use_ssl
       attr_accessor :retry
+      attr_accessor :open_timeout
+      attr_accessor :read_timeout
+      attr_accessor :max_delay
 
       attr_accessor :series_name_for_controller_runtimes
       attr_accessor :series_name_for_view_runtimes
@@ -50,6 +53,9 @@ module InfluxDB
         :async              => true,
         :use_ssl            => false,
         :retry              => nil,
+        :open_timeout       => 5,
+        :read_timeout       => 300,
+        :max_delay          => 30,
 
         :series_name_for_controller_runtimes  => "rails.controller",
         :series_name_for_view_runtimes        => "rails.view",
@@ -93,6 +99,9 @@ module InfluxDB
         @async              = DEFAULTS[:async]
         @use_ssl            = DEFAULTS[:use_ssl]
         @retry              = DEFAULTS[:retry]
+        @open_timeout       = DEFAULTS[:open_timeout]
+        @read_timeout       = DEFAULTS[:read_timeout]
+        @max_delay          = DEFAULTS[:max_delay]
 
         @series_name_for_controller_runtimes  = DEFAULTS[:series_name_for_controller_runtimes]
         @series_name_for_view_runtimes        = DEFAULTS[:series_name_for_view_runtimes]

--- a/spec/unit/configuration_spec.rb
+++ b/spec/unit/configuration_spec.rb
@@ -42,4 +42,48 @@ RSpec.describe InfluxDB::Rails::Configuration do
     end
   end
 
+  describe "#open_timeout" do
+    it "defaults to 5" do
+      InfluxDB::Rails.configure do |config|
+      end
+      expect(InfluxDB::Rails.configuration.open_timeout).to eql(5)
+    end
+
+    it "can be updated" do
+      InfluxDB::Rails.configure do |config|
+        config.open_timeout = 5
+      end
+      expect(InfluxDB::Rails.configuration.open_timeout).to eql(5)
+    end
+  end
+
+  describe "#read_timeout" do
+    it "defaults to 300" do
+      InfluxDB::Rails.configure do |config|
+      end
+      expect(InfluxDB::Rails.configuration.read_timeout).to eql(300)
+    end
+
+    it "can be updated" do
+      InfluxDB::Rails.configure do |config|
+        config.read_timeout = 5
+      end
+      expect(InfluxDB::Rails.configuration.read_timeout).to eql(5)
+    end
+  end
+
+  describe "#max_delay" do
+    it "defaults to 30" do
+      InfluxDB::Rails.configure do |config|
+      end
+      expect(InfluxDB::Rails.configuration.max_delay).to eql(30)
+    end
+
+    it "can be updated" do
+      InfluxDB::Rails.configure do |config|
+        config.max_delay = 5
+      end
+      expect(InfluxDB::Rails.configuration.max_delay).to eql(5)
+    end
+  end
 end


### PR DESCRIPTION
Hello!, I'd like to use `open_timeout`, `read_timeout` and `max_delay` as configuration options for `InfluxDB::Client`, for that reason I created this PR. Thanks for the gem!