### PR TITLE
Adds support for influxdb timestamp precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ InfluxDB::Rails.configure do |config|
   # config.open_timeout = 5
   # config.read_timeout = 30
   # config.max_delay = 300
+  # config.time_precision = 'ms'
 
   # config.series_name_for_controller_runtimes = "rails.controller"
   # config.series_name_for_view_runtimes       = "rails.view"

--- a/lib/influxdb/rails/configuration.rb
+++ b/lib/influxdb/rails/configuration.rb
@@ -12,6 +12,7 @@ module InfluxDB
       attr_accessor :open_timeout
       attr_accessor :read_timeout
       attr_accessor :max_delay
+      attr_accessor :time_precision
 
       attr_accessor :series_name_for_controller_runtimes
       attr_accessor :series_name_for_view_runtimes
@@ -58,6 +59,7 @@ module InfluxDB
         :open_timeout       => 5,
         :read_timeout       => 300,
         :max_delay          => 30,
+        :time_precision     => "s",
 
         :series_name_for_controller_runtimes  => "rails.controller",
         :series_name_for_view_runtimes        => "rails.view",
@@ -104,6 +106,7 @@ module InfluxDB
         @open_timeout       = DEFAULTS[:open_timeout]
         @read_timeout       = DEFAULTS[:read_timeout]
         @max_delay          = DEFAULTS[:max_delay]
+        @time_precision     = DEFAULTS[:time_precision]
 
         @series_name_for_controller_runtimes  = DEFAULTS[:series_name_for_controller_runtimes]
         @series_name_for_view_runtimes        = DEFAULTS[:series_name_for_view_runtimes]

--- a/lib/influxdb/rails/exception_presenter.rb
+++ b/lib/influxdb/rails/exception_presenter.rb
@@ -40,7 +40,7 @@ module InfluxDB
 
       def context
         c = {
-          :time => Time.now.utc.to_i,
+          :time => InfluxDB::Rails.current_timestamp,
           :application_name => InfluxDB::Rails.configuration.application_name,
           :application_root => InfluxDB::Rails.configuration.application_root,
           :framework => InfluxDB::Rails.configuration.framework,

--- a/spec/unit/configuration_spec.rb
+++ b/spec/unit/configuration_spec.rb
@@ -86,4 +86,19 @@ RSpec.describe InfluxDB::Rails::Configuration do
       expect(InfluxDB::Rails.configuration.max_delay).to eql(5)
     end
   end
+
+  describe "#time_precision" do
+    it "defaults to seconds" do
+      InfluxDB::Rails.configure do |config|
+      end
+      expect(InfluxDB::Rails.configuration.time_precision).to eql('s')
+    end
+
+    it "can be updated" do
+      InfluxDB::Rails.configure do |config|
+        config.time_precision = 'ms'
+      end
+      expect(InfluxDB::Rails.configuration.time_precision).to eql('ms')
+    end
+  end
 end

--- a/spec/unit/influxdb_rails_spec.rb
+++ b/spec/unit/influxdb_rails_spec.rb
@@ -5,6 +5,55 @@ RSpec.describe InfluxDB::Rails do
     InfluxDB::Rails.configure { |config| config.ignored_environments = [] }
   end
 
+  describe '.convert_timestamp' do
+    let(:sometime) { Time.parse('2017-12-11 16:20:29.111222333 UTC') }
+    let(:configuration) { double("Configuration") }
+    before { allow(InfluxDB::Rails).to receive(:configuration).and_return configuration }
+
+    it "should return the timestamp in nanoseconds when precision is 'ns'" do
+      allow(configuration).to receive(:time_precision).and_return('ns')
+      expect(InfluxDB::Rails.convert_timestamp(sometime)).to eq(1513009229111222272)
+    end
+    it "should return the timestamp in nanoseconds when precision is nil" do
+      allow(configuration).to receive(:time_precision)
+      expect(InfluxDB::Rails.convert_timestamp(sometime)).to eq(1513009229111222272)
+    end
+    it "should return the timestamp in microseconds when precision is u" do
+      allow(configuration).to receive(:time_precision).and_return('u')
+      expect(InfluxDB::Rails.convert_timestamp(sometime)).to eq(1513009229111222)
+    end
+    it "should return the timestamp in milliseconds when precision is ms" do
+      allow(configuration).to receive(:time_precision).and_return('ms')
+      expect(InfluxDB::Rails.convert_timestamp(sometime)).to eq(1513009229111)
+    end
+    it "should return the timestamp in seconds when precision is s" do
+      allow(configuration).to receive(:time_precision).and_return('s')
+      expect(InfluxDB::Rails.convert_timestamp(sometime)).to eq(1513009229)
+    end
+    it "should return the timestamp in minutes when precision is m" do
+      allow(configuration).to receive(:time_precision).and_return('m')
+      expect(InfluxDB::Rails.convert_timestamp(sometime)).to eq(25216820)
+    end
+    it "should return the timestamp in hours when precision is h" do
+      allow(configuration).to receive(:time_precision).and_return('h')
+      expect(InfluxDB::Rails.convert_timestamp(sometime)).to eq(420280)
+    end
+    it "should raise an excpetion when precision is unrecognized" do
+      allow(configuration).to receive(:time_precision).and_return('whatever')
+      expect{InfluxDB::Rails.convert_timestamp(sometime)}.
+        to raise_exception /invalid time precision.*whatever/i
+    end
+  end
+
+  describe '.current_timestamp' do
+    it "should return the current timestamp in the configured precision" do
+      now = Time.parse('2017-12-11 16:20:29.111222333 UTC')
+      allow(Time).to receive(:now).and_return(now)
+      InfluxDB::Rails.configure {|config| config.time_precision = 'ms'}
+      expect(InfluxDB::Rails.current_timestamp).to eq(1513009229111)
+    end
+  end
+
   describe ".ignorable_exception?" do
     it "should be true for exception types specified in the configuration" do
       class DummyException < Exception; end


### PR DESCRIPTION
### Background / Motivation

The current implementation of `influxdb-rails` makes no provisions with respect to the precision of timestamps. Action controller metrics do not specify a timestamp value, while exception reports specify a timestamp in seconds (using `#to_i` on a `Time` object). In any case, the default precision of `influxdb-ruby` applies which is seconds.

This implies that multiple points with the same timestamp in seconds and the same tags (say `method` and `server`) will result in data loss as [only one (the most recent) will be stored in influxdb](https://docs.influxdata.com/influxdb/v1.3/troubleshooting/frequently-asked-questions/#how-does-influxdb-handle-duplicate-points). For load-balanced web applications that serve multiple requests per second, this implies that measurements will surely be lost.

### Approach / Implementation

The  `influxdb-ruby` gem already exposes a `time_precision` parameter in the client's initialization. This parameter is now also exposed in the configuration of `InfluxDB::Rails` and is taken into consideration when generating timestamps for action controller metrics and exception reports following [these guidelines](https://github.com/influxdata/influxdb-ruby#a-note-about-time-precision).

Please note that the default precision of seconds has been preserved in order to ensure backwards compatibility. 