### PR TITLE
Add ability to extend passed tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ InfluxDB::Rails.configure do |config|
   # config.max_delay = 300
   # config.time_precision = 'ms'
 
+  # config.tags_middleware = ->(tags) { tags }
+
   # config.series_name_for_controller_runtimes = "rails.controller"
   # config.series_name_for_view_runtimes       = "rails.view"
   # config.series_name_for_db_runtimes         = "rails.db"
@@ -71,6 +73,16 @@ underlying `InfluxDB::Client` object to write arbitrary data like this:
 InfluxDB::Rails.client.write_point "events",
   tags:   { url: "/foo", user_id: current_user.id },
   values: { value: 0 }
+```
+
+You can modify tags, are going to be sent to InfluxDB by defining the `tags_middleware`.
+
+```ruby
+InfluxDB::Rails.configure do |config|
+  config.tags_middleware = ->(tags) do
+    tags.merge(env: Rails.env)
+  end
+end
 ```
 
 Additional documentation for `InfluxDB::Client` lives in the

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ InfluxDB::Rails.client.write_point "events",
   values: { value: 0 }
 ```
 
+Additional documentation for `InfluxDB::Client` lives in the
+[influxdb-ruby](http://github.com/influxdata/influxdb-ruby) repo.
+
 ### Tags
 
 You can modify tags, that are sent to InfluxDB by defining the `tags_middleware`.
@@ -115,9 +118,6 @@ and for the exceptions:
   status:   "open",
 }
 ```
-
-Additional documentation for `InfluxDB::Client` lives in the
-[influxdb-ruby](http://github.com/influxdata/influxdb-ruby) repo.
 
 ## Frequently Asked Questions
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You can modify tags, that are sent to InfluxDB by defining the `tags_middleware`
 
 ```ruby
 InfluxDB::Rails.configure do |config|
-  config.tags_middleware = ->(tags) do
+  config.tags_middleware = lambda do |tags|
     tags.merge(env: Rails.env)
   end
 end

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ InfluxDB::Rails.client.write_point "events",
   values: { value: 0 }
 ```
 
-You can modify tags, are going to be sent to InfluxDB by defining the `tags_middleware`.
+### Tags
+
+You can modify tags, that are sent to InfluxDB by defining the `tags_middleware`.
 
 ```ruby
 InfluxDB::Rails.configure do |config|
@@ -83,6 +85,35 @@ InfluxDB::Rails.configure do |config|
     tags.merge(env: Rails.env)
   end
 end
+```
+
+By default, the following tags are sent for **actions series**:
+
+```ruby
+{
+  method:   "#{payload[:controller]}##{payload[:action]}",
+  server:   Socket.gethostname,
+  app_name: configuration.application_name,
+}
+```
+
+and for the exceptions:
+
+```ruby
+{
+  application_name:   InfluxDB::Rails.configuration.application_name,
+  application_root:   InfluxDB::Rails.configuration.application_root,
+  framework:          InfluxDB::Rails.configuration.framework,
+  framework_version:  InfluxDB::Rails.configuration.framework_version,
+  language:           "Ruby",
+  language_version:   "#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}",
+  custom_data:        @custom_data,
+  class:    @exception.class.to_s,
+  method:   "#{@controller}##{@action}",
+  filename: File.basename(@backtrace.lines.first.try(:file)),
+  server:   Socket.gethostname,
+  status:   "open",
+}
 ```
 
 Additional documentation for `InfluxDB::Client` lives in the

--- a/lib/influxdb-rails.rb
+++ b/lib/influxdb-rails.rb
@@ -69,11 +69,14 @@ module InfluxDB
         env = influxdb_request_data if env.empty? && defined? influxdb_request_data
         exception_presenter = ExceptionPresenter.new(e, env)
         log :info, "Exception: #{exception_presenter.to_json[0..512]}..."
+        tags = configuration.tags_middleware.call(
+          exception_presenter.context.merge(exception_presenter.dimensions)
+        )
 
         client.write_point \
           configuration.series_name_for_exceptions,
           values:    exception_presenter.values.merge(ts: timestamp),
-          tags:      exception_presenter.context.merge(exception_presenter.dimensions),
+          tags:      tags,
           timestamp: timestamp
       rescue StandardError => e
         log :info, "[InfluxDB::Rails] Something went terribly wrong." \
@@ -82,11 +85,11 @@ module InfluxDB
       alias transmit report_exception
 
       def handle_action_controller_metrics(_name, start, finish, _id, payload)
-        tags = {
+        tags = configuration.tags_middleware.call({
           method:   "#{payload[:controller]}##{payload[:action]}",
           server:   Socket.gethostname,
           app_name: configuration.application_name,
-        }.reject { |_, value| value.nil? }
+        }.reject { |_, value| value.nil? })
 
         ts = convert_timestamp(finish.utc)
 

--- a/lib/influxdb/rails/configuration.rb
+++ b/lib/influxdb/rails/configuration.rb
@@ -22,6 +22,8 @@ module InfluxDB
       attr_accessor :series_name_for_exceptions
       attr_accessor :series_name_for_instrumentation
 
+      attr_accessor :tags_middleware
+
       attr_accessor :rails_app_name
 
       attr_accessor :application_name
@@ -66,6 +68,7 @@ module InfluxDB
         series_name_for_exceptions:           "rails.exceptions".freeze,
         series_name_for_instrumentation:      "instrumentation".freeze,
 
+        tags_middleware: ->(tags) { tags },
         rails_app_name: nil,
 
         ignored_exceptions: %w[
@@ -124,6 +127,7 @@ module InfluxDB
         @series_name_for_exceptions           = DEFAULTS[:series_name_for_exceptions]
         @series_name_for_instrumentation      = DEFAULTS[:series_name_for_instrumentation]
 
+        @tags_middleware = DEFAULTS[:tags_middleware]
         @rails_app_name = DEFAULTS[:rails_app_name]
 
         @ignored_exceptions           = DEFAULTS[:ignored_exceptions].dup

--- a/lib/influxdb/rails/instrumentation.rb
+++ b/lib/influxdb/rails/instrumentation.rb
@@ -13,10 +13,10 @@ module InfluxDB
           values: {
             value: ((Time.now - start) * 1000).ceil,
           },
-          tags: {
+          tags: configuration.tags_middleware.call(
             method: "#{controller_name}##{action_name}",
             server: Socket.gethostname,
-          }
+          )
       end
 
       def self.included(base)

--- a/spec/unit/configuration_spec.rb
+++ b/spec/unit/configuration_spec.rb
@@ -105,4 +105,21 @@ RSpec.describe InfluxDB::Rails::Configuration do
       expect(InfluxDB::Rails.configuration.rails_app_name).to eq('my-app')
     end
   end
+
+  describe "#tags_middleware" do
+    let(:middleware) { InfluxDB::Rails.configuration.tags_middleware }
+    let(:tags_example) { {a: 1, b: 2} }
+
+    it 'by default returns unmodified tags' do
+      expect(middleware.call(tags_example)).to eq tags_example
+    end
+
+    it "can be updated" do
+      InfluxDB::Rails.configure do |config|
+        config.tags_middleware = ->(tags) { tags.merge(c: 3) }
+      end
+
+      expect(middleware.call(tags_example)).to eq(tags_example.merge(c: 3))
+    end
+  end
 end

--- a/spec/unit/influxdb_rails_spec.rb
+++ b/spec/unit/influxdb_rails_spec.rb
@@ -41,19 +41,40 @@ RSpec.describe InfluxDB::Rails do
 
     context 'application_name is nil' do
       before do
-        InfluxDB::Rails.configure do |config|
-          config.application_name = nil
-        end
+        allow(InfluxDB::Rails.configuration).to receive(:application_name).and_return(nil)
       end
 
       it 'doesn not add the app_name tag to metrics' do
         tags = { method: 'MyController#show', server: Socket.gethostname }
 
-        expect_any_instance_of(InfluxDB::Client).to receive(:write_point).with(
-          'rails.controller', data.merge(values: { value: 2000 }, tags: tags)
-        )
-        expect_any_instance_of(InfluxDB::Client).to receive(:write_point).with('rails.view', data.merge(tags: tags))
-        expect_any_instance_of(InfluxDB::Client).to receive(:write_point).with('rails.db', data.merge(tags: tags))
+        expect_any_instance_of(InfluxDB::Client)
+          .to receive(:write_point).with('rails.controller', include(tags: tags))
+        expect_any_instance_of(InfluxDB::Client)
+          .to receive(:write_point).with('rails.view', include(tags: tags))
+        expect_any_instance_of(InfluxDB::Client)
+          .to receive(:write_point).with('rails.db', include(tags: tags))
+
+        described_class.handle_action_controller_metrics('unused', start, finish, 'unused', payload)
+      end
+    end
+
+    context 'when tags_middleware is overwritten' do
+      before do
+        allow(InfluxDB::Rails.configuration)
+          .to receive(:tags_middleware).and_return(tags_middleware)
+      end
+
+      let(:tags_middleware) { ->(tags) { tags.merge(static: 'value') } }
+
+      it 'processes tags throught the middleware' do
+        tags = data[:tags].merge(static: 'value')
+
+        expect_any_instance_of(InfluxDB::Client)
+          .to receive(:write_point).with('rails.controller', include(tags: tags))
+        expect_any_instance_of(InfluxDB::Client)
+          .to receive(:write_point).with('rails.view', include(tags: tags))
+        expect_any_instance_of(InfluxDB::Client)
+          .to receive(:write_point).with('rails.db', include(tags: tags))
 
         described_class.handle_action_controller_metrics('unused', start, finish, 'unused', payload)
       end


### PR DESCRIPTION
Fixes #30 

It's often desirable to put extra tags to the series being sent. Here is a proposal to implement it via `InfluxDB::Rails.configuration.tags_middleware`. Having a proc is much more flexible than having a static `extra_tags` hash since you can put different tags depending on current tags.

Since test coverage isn't too big, I put tests only for what is tested.