### PR TITLE
Use snake_case for initializer file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To get things set up, just create an initializer:
 
 ```
 $ cd /to/you/rails/application
-$ touch config/initializers/influxdb-rails.rb
+$ touch config/initializers/influxdb_rails.rb
 ```
 
 In this file, you can configure the `InfluxDB::Rails` adapter. The default

--- a/lib/rails/generators/influxdb/influxdb_generator.rb
+++ b/lib/rails/generators/influxdb/influxdb_generator.rb
@@ -6,7 +6,7 @@ class InfluxdbGenerator < Rails::Generators::Base # rubocop:disable Style/Docume
   source_root File.expand_path('../templates', __FILE__)
 
   def copy_initializer_file
-    template "initializer.rb", "config/initializers/influxdb-rails.rb"
+    template "initializer.rb", "config/initializers/influxdb_rails.rb"
   end
 
   def install


### PR DESCRIPTION
This is the Ruby convention.
A project with RuboCop configured will fail because not following this convention.

https://github.com/rubocop-hq/ruby-style-guide#snake-case-files