### PR TITLE
Add method, status and format tags to metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ gemfiles/*.lock
 pkg/*
 spec/support/rails*/log/*
 .ruby-*
+vendor/bundle

--- a/lib/influxdb-rails.rb
+++ b/lib/influxdb-rails.rb
@@ -83,9 +83,13 @@ module InfluxDB
 
       def handle_action_controller_metrics(_name, start, finish, _id, payload)
         tags = {
-          method:   "#{payload[:controller]}##{payload[:action]}",
-          server:   Socket.gethostname,
-          app_name: configuration.application_name,
+          method:        "#{payload[:controller]}##{payload[:action]}",
+          status:        payload[:status],
+          format:        payload[:format],
+          http_method:   payload[:method],
+          path:          payload[:path],
+          server:        Socket.gethostname,
+          app_name:      configuration.application_name,
         }.reject { |_, value| value.nil? }
 
         ts = convert_timestamp(finish.utc)

--- a/spec/unit/influxdb_rails_spec.rb
+++ b/spec/unit/influxdb_rails_spec.rb
@@ -12,16 +12,20 @@ RSpec.describe InfluxDB::Rails do
   describe '.handle_action_controller_metrics' do
     let(:start)   { Time.at(1_517_567_368) }
     let(:finish)  { Time.at(1_517_567_370) }
-    let(:payload) { { view_runtime: 2, db_runtime: 2, controller: 'MyController', action: 'show' } }
+    let(:payload) { { view_runtime: 2, db_runtime: 2, controller: 'MyController', action: 'show', method: 'GET', format: '*/*', path: '/posts', status: 200 } }
     let(:data)    do
       {
         values: {
           value: 2
         },
         tags: {
-          method: 'MyController#show',
-          server: Socket.gethostname,
-          app_name: 'my-rails-app',
+          method:      'MyController#show',
+          status:      200,
+          format:      '*/*',
+          http_method: 'GET',
+          path:        '/posts',
+          server:      Socket.gethostname,
+          app_name:    'my-rails-app',
         },
         timestamp: 1_517_567_370_000
       }
@@ -47,7 +51,14 @@ RSpec.describe InfluxDB::Rails do
       end
 
       it 'doesn not add the app_name tag to metrics' do
-        tags = { method: 'MyController#show', server: Socket.gethostname }
+        tags = {
+          method:      'MyController#show',
+          status:      200,
+          format:      '*/*',
+          http_method: 'GET',
+          path:        '/posts',
+          server:      Socket.gethostname,
+        }
 
         expect_any_instance_of(InfluxDB::Client).to receive(:write_point).with(
           'rails.controller', data.merge(values: { value: 2000 }, tags: tags)


### PR DESCRIPTION
These values are provided by the payload anyway
and will allow very interesting queries like

* group / count only successfull requests
* group / count only GET requests
* group / count only JSON requests

I think these tags should be included by default because they're potentially interesting for all users.