### PR TITLE
Fix typ in method name in Rails::Instrumentation

### DIFF
--- a/lib/influxdb/rails/instrumentation.rb
+++ b/lib/influxdb/rails/instrumentation.rb
@@ -1,7 +1,7 @@
 module InfluxDB
   module Rails
     module Instrumentation # rubocop:disable Style/Documentation
-      def benchmark_for_instrumentationn # rubocop:disable Metrics/MethodLength
+      def benchmark_for_instrumentation # rubocop:disable Metrics/MethodLength
         start = Time.now
         yield
 


### PR DESCRIPTION
s/benchmark_for_instrumentations/benchmark_for_instrumentation/

This was called wrong in the around filter in the same class.