### PR TITLE
Drop HTTP request path as tag

### DIFF
--- a/lib/influxdb-rails.rb
+++ b/lib/influxdb-rails.rb
@@ -87,7 +87,6 @@ module InfluxDB
           status:      payload[:status],
           format:      payload[:format],
           http_method: payload[:method],
-          path:        payload[:path],
           server:      Socket.gethostname,
           app_name:    configuration.application_name,
         }.reject { |_, value| value.nil? }

--- a/spec/unit/influxdb_rails_spec.rb
+++ b/spec/unit/influxdb_rails_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe InfluxDB::Rails do
   describe ".handle_action_controller_metrics" do
     let(:start)   { Time.at(1_517_567_368) }
     let(:finish)  { Time.at(1_517_567_370) }
-    let(:payload) { { view_runtime: 2, db_runtime: 2, controller: "MyController", action: "show", method: "GET", format: "*/*", path: "/posts", status: 200 } }
+    let(:payload) { { view_runtime: 2, db_runtime: 2, controller: "MyController", action: "show", method: "GET", format: "*/*", status: 200 } }
     let(:data)    do
       {
         values:    {
@@ -23,7 +23,6 @@ RSpec.describe InfluxDB::Rails do
           status:      200,
           format:      "*/*",
           http_method: "GET",
-          path:        "/posts",
           server:      Socket.gethostname,
           app_name:    "my-rails-app",
         },
@@ -56,7 +55,6 @@ RSpec.describe InfluxDB::Rails do
           status:      200,
           format:      "*/*",
           http_method: "GET",
-          path:        "/posts",
           server:      Socket.gethostname,
         }
 


### PR DESCRIPTION
The HTTP request path contains variable values / parameters.
This does not make it suitable for tags and frequently causes
'exceed tag value limit' errors in InfluxDB.

We had the beta running in production and this caused a 'exceed tag value limit'  error within a few hours. I think including the HTTP request path does not make much sense because of it's variable nature.