### PR TITLE
Move count and cache_hits tags to values

### DIFF
--- a/lib/influxdb/rails/middleware/render_subscriber.rb
+++ b/lib/influxdb/rails/middleware/render_subscriber.rb
@@ -6,12 +6,17 @@ module InfluxDB
       class RenderSubscriber < SimpleSubscriber # :nodoc:
         private
 
+        def values(started, finished, payload)
+          super(started, finished, payload).merge(
+            count:      payload[:count],
+            cache_hits: payload[:cache_hits]
+          ).reject { |_, value| value.nil? }
+        end
+
         def tags(payload)
           tags = {
-            location:   location,
-            filename:   payload[:identifier],
-            count:      payload[:count],
-            cache_hits: payload[:cache_hits],
+            location: location,
+            filename: payload[:identifier],
           }
           super(tags)
         end

--- a/spec/unit/middleware/render_subscriber_spec.rb
+++ b/spec/unit/middleware/render_subscriber_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe InfluxDB::Rails::Middleware::RenderSubscriber do
     let(:data) do
       {
         values:    {
-          value: 2000
-        },
-        tags:      {
-          filename:   "index.html",
-          location:   "Foo#bar",
+          value:      2000,
           count:      43,
           cache_hits: 42
+        },
+        tags:      {
+          filename: "index.html",
+          location: "Foo#bar",
         },
         timestamp: 1_517_567_370_000
       }
@@ -52,13 +52,13 @@ RSpec.describe InfluxDB::Rails::Middleware::RenderSubscriber do
 
       it_behaves_like "with additional tags", ["series_name"]
 
-      context "with empty tags" do
+      context "with an empty value" do
         before do
           payload[:count] = nil
-          data[:tags].delete(:count)
+          data[:values].delete(:count)
         end
 
-        it "does not write empty tags" do
+        it "does not write empty value" do
           expect_any_instance_of(InfluxDB::Client).to receive(:write_point).with(
             series_name, data
           )


### PR DESCRIPTION
These two values have a high cardinality and therefore
it does not make sense to use them as tags. Therefore
we move them over to values instead.