### PR TITLE
use current timestamp instead of finished monotonic time

### DIFF
--- a/influxdb-rails.gemspec
+++ b/influxdb-rails.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-rails", ">= 3.0.0"
   spec.add_development_dependency "rubocop", "~> 0.61.1"
-  spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "sqlite3", "~> 1.3.6"
   spec.add_development_dependency "tzinfo"
 end

--- a/lib/influxdb/rails/middleware/request_subscriber.rb
+++ b/lib/influxdb/rails/middleware/request_subscriber.rb
@@ -7,7 +7,6 @@ module InfluxDB
         def call(_name, start, finish, _id, payload) # rubocop:disable Metrics/MethodLength
           return unless enabled?
 
-          finished = InfluxDB.convert_timestamp(finish.utc, configuration.time_precision)
           started = InfluxDB.convert_timestamp(start.utc, configuration.time_precision)
           tags = tags(payload)
           begin
@@ -16,7 +15,7 @@ module InfluxDB
                 series_name,
                 values:    values(value, started),
                 tags:      tags,
-                timestamp: finished
+                timestamp: InfluxDB::Rails.current_timestamp
             end
           rescue StandardError => e
             log :error, "[InfluxDB::Rails] Unable to write points: #{e.message}"

--- a/lib/influxdb/rails/middleware/simple_subscriber.rb
+++ b/lib/influxdb/rails/middleware/simple_subscriber.rb
@@ -21,7 +21,7 @@ module InfluxDB
             InfluxDB::Rails.client.write_point series_name,
                                                values:    values(started, finished, payload),
                                                tags:      tags(payload),
-                                               timestamp: timestamp(finished.utc)
+                                               timestamp: InfluxDB::Rails.current_timestamp
           rescue StandardError => e
             log :error, "[InfluxDB::Rails] Unable to write points: #{e.message}"
           end
@@ -34,10 +34,6 @@ module InfluxDB
           result.merge(InfluxDB::Rails.current.values).reject do |_, value|
             value.nil? || value == ""
           end
-        end
-
-        def timestamp(finished)
-          InfluxDB.convert_timestamp(finished.utc, configuration.time_precision)
         end
 
         def enabled?

--- a/spec/unit/middleware/render_subscriber_spec.rb
+++ b/spec/unit/middleware/render_subscriber_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe InfluxDB::Rails::Middleware::RenderSubscriber do
     context "successfully" do
       it "writes to InfluxDB" do
         expect_any_instance_of(InfluxDB::Client).to receive(:write_point).with(
-          series_name, data
+          series_name, data.merge(timestamp: InfluxDB::Rails.current_timestamp)
         )
         subject.call("name", start, finish, "id", payload)
       end
@@ -60,7 +60,7 @@ RSpec.describe InfluxDB::Rails::Middleware::RenderSubscriber do
 
         it "does not write empty value" do
           expect_any_instance_of(InfluxDB::Client).to receive(:write_point).with(
-            series_name, data
+            series_name, data.merge(timestamp: InfluxDB::Rails.current_timestamp)
           )
           subject.call("name", start, finish, "id", payload)
         end

--- a/spec/unit/middleware/request_subscriber_spec.rb
+++ b/spec/unit/middleware/request_subscriber_spec.rb
@@ -39,10 +39,10 @@ RSpec.describe InfluxDB::Rails::Middleware::RequestSubscriber do
 
       it "sends metrics with taggings and timestamps" do
         expect_any_instance_of(InfluxDB::Client).to receive(:write_point).with(
-          "rails.controller", data.deep_merge(values: { value: 2000 })
+          "rails.controller", data.deep_merge(values: { value: 2000 }, timestamp: InfluxDB::Rails.current_timestamp)
         )
-        expect_any_instance_of(InfluxDB::Client).to receive(:write_point).with("rails.view", data)
-        expect_any_instance_of(InfluxDB::Client).to receive(:write_point).with("rails.db", data)
+        expect_any_instance_of(InfluxDB::Client).to receive(:write_point).with("rails.view", data.merge(timestamp: InfluxDB::Rails.current_timestamp))
+        expect_any_instance_of(InfluxDB::Client).to receive(:write_point).with("rails.db", data.merge(timestamp: InfluxDB::Rails.current_timestamp))
 
         subject.call("unused", start, finish, "unused", payload)
       end
@@ -67,10 +67,10 @@ RSpec.describe InfluxDB::Rails::Middleware::RequestSubscriber do
 
       it "does not add the app_name tag to metrics" do
         expect_any_instance_of(InfluxDB::Client).to receive(:write_point).with(
-          "rails.controller", data.merge(tags: tags).deep_merge(values: { value: 2000 })
+          "rails.controller", data.merge(tags: tags).deep_merge(values: { value: 2000 }, timestamp: InfluxDB::Rails.current_timestamp)
         )
-        expect_any_instance_of(InfluxDB::Client).to receive(:write_point).with("rails.view", data.merge(tags: tags))
-        expect_any_instance_of(InfluxDB::Client).to receive(:write_point).with("rails.db", data.merge(tags: tags))
+        expect_any_instance_of(InfluxDB::Client).to receive(:write_point).with("rails.view", data.merge(tags: tags, timestamp: InfluxDB::Rails.current_timestamp))
+        expect_any_instance_of(InfluxDB::Client).to receive(:write_point).with("rails.db", data.merge(tags: tags, timestamp: InfluxDB::Rails.current_timestamp))
 
         subject.call("unused", start, finish, "unused", payload)
       end

--- a/spec/unit/middleware/sql_subscriber_spec.rb
+++ b/spec/unit/middleware/sql_subscriber_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe InfluxDB::Rails::Middleware::SqlSubscriber do
     context "successfully" do
       it "writes to InfluxDB" do
         expect_any_instance_of(InfluxDB::Client).to receive(:write_point).with(
-          series_name, data
+          series_name, data.merge(timestamp: InfluxDB::Rails.current_timestamp)
         )
         subject.call("name", start, finish, "id", payload)
       end
@@ -72,7 +72,7 @@ RSpec.describe InfluxDB::Rails::Middleware::SqlSubscriber do
         it "does use the default location" do
           data[:tags] = data[:tags].merge(location: :raw)
           expect_any_instance_of(InfluxDB::Client).to receive(:write_point).with(
-            series_name, data
+            series_name, data.merge(timestamp: InfluxDB::Rails.current_timestamp)
           )
           subject.call("name", start, finish, "id", payload)
         end


### PR DESCRIPTION
Normally, a developer expects a data point being inserted into influxdb with a timestamp of the current time. However, this project inserts a timestamp of the finished monotonic time which gets passed from rails' `ActiveSupport:: Notifications `([code](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/notifications.rb)). 

This confused me a lot when I first received lots of timestampes like `717690.570250131`.... I calculated with lots of ways to figure out what does that timestamp mean, and finally managed to know that those timestamps are very close to the time since I reboot my mac. Then I searched and realized that `time since last reboot` has a term called `monotonic time`. I digged into rails source code and got to know that was happening.

I don't know what was the exact purpose of putting finished `monotonic time` into influxdb for timestamps, or it was just a small mistake.

Code fixed upon my issue, and tests all passed.