### PR TITLE
Bump version to 0.4.999

### DIFF
--- a/influxdb-rails.gemspec
+++ b/influxdb-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
     "source_code_uri"   => "https://github.com/influxdata/influxdb-rails"
   }
 
-  s.files         = Dir.glob('**/*')
+  s.files         = `git ls-files`.split($/)
   s.test_files    = Dir.glob('test/**/*') + Dir.glob('spec/**/*') + Dir.glob('features/**/*')
   s.executables   = Dir.glob('bin/**/*').map {|f| File.basename(f)}
   s.require_paths = ["lib"]

--- a/lib/influxdb/rails/version.rb
+++ b/lib/influxdb/rails/version.rb
@@ -1,5 +1,5 @@
 module InfluxDB
   module Rails
-    VERSION = "0.4.99"
+    VERSION = "0.4.999"
   end
 end


### PR DESCRIPTION
Version 0.4.99 was broken because it contained all vendor libraries. I yanked the gem and published a fixed version immediately. 

https://rubygems.org/gems/influxdb-rails/versions/0.4.999
https://rubygems.org/gems/influxdb-rails/versions/0.4.99