### PR TITLE
Ability to overwrite the `auth_method` in the ClientConfig

### DIFF
--- a/lib/influxdb-rails.rb
+++ b/lib/influxdb-rails.rb
@@ -36,6 +36,7 @@ module InfluxDB
             database:       cfg.database,
             username:       cfg.username,
             password:       cfg.password,
+            auth_method:    cfg.auth_method,
             hosts:          cfg.hosts,
             port:           cfg.port,
             async:          cfg.async,

--- a/lib/influxdb/rails/configuration.rb
+++ b/lib/influxdb/rails/configuration.rb
@@ -34,6 +34,7 @@ module InfluxDB
         username:       "root".freeze,
         password:       "root".freeze,
         database:       nil,
+        auth_method:    "params".freeze,
         async:          true,
         use_ssl:        false,
         retry:          nil,


### PR DESCRIPTION
I have a requirement of using auth via `basic_auth`, however, I was unable to figure out how to make it work with this library. So I made the required changes to support the "right way" to configure it.

See https://github.com/influxdata/influxdb-rails/issues/95 for more information.
