### PR TITLE
Implement save_and_open_metric helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pkg/*
 spec/support/rails*/log/*
 .ruby-*
 vendor/bundle
+tmp

--- a/influxdb-rails.gemspec
+++ b/influxdb-rails.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "activerecord"
   spec.add_development_dependency "bundler", ">= 1.0.0"
   spec.add_development_dependency "fakeweb"
+  spec.add_development_dependency "launchy"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rdoc"

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,18 +1,34 @@
 require File.expand_path(File.dirname(__FILE__) + "/test_client")
+require "launchy"
 
 module InfluxDB
   module Rails
     module Matchers
       def expect_metric(name: "rails", **options)
-        expect(TestClient.metrics).to include(
+        expect(metrics).to include(
           a_hash_including(options.merge(name: name))
         )
       end
 
       def expect_no_metric(name: "rails", **options)
-        expect(TestClient.metrics).not_to include(
+        expect(metrics).not_to include(
           a_hash_including(options.merge(name: name))
         )
+      end
+
+      def save_and_open_metrics
+        dir = File.join(File.dirname(__FILE__), "..", "..", "tmp")
+        FileUtils.mkdir_p(dir)
+        file_path = File.join(dir, "metrics.json")
+        output = JSON.pretty_generate(metrics)
+        File.write(file_path, output, mode: "wb")
+        ::Launchy.open(file_path)
+      end
+
+      private
+
+      def metrics
+        TestClient.metrics
       end
     end
   end


### PR DESCRIPTION
Implement a `save_and_open_metric` helper, it will open a JSON file with the saved metrics which is helpful for debugging in your specs.

```ruby
it "creates metrics" do
  get "/metrics"

  save_and_open_metrics
end
```

Based on https://github.com/influxdata/influxdb-rails/pull/89