### PR TITLE
Reduce number of current attributes

### DIFF
--- a/lib/influxdb/rails/context.rb
+++ b/lib/influxdb/rails/context.rb
@@ -1,59 +1,25 @@
 module InfluxDB
   module Rails
     class Context
-      def controller
-        Thread.current[:_influxdb_rails_controller]
-      end
-
-      def controller=(value)
-        Thread.current[:_influxdb_rails_controller] = value
-      end
-
-      def action
-        Thread.current[:_influxdb_rails_action]
-      end
-
-      def action=(value)
-        Thread.current[:_influxdb_rails_action] = value
-      end
-
-      def request_id=(value)
-        Thread.current[:_influxdb_rails_request_id] = value
-      end
-
-      def request_id
-        Thread.current[:_influxdb_rails_request_id]
-      end
-
-      def location
-        [
-          controller,
-          action,
-        ].reject(&:blank?).join("#")
-      end
-
       def reset
-        Thread.current[:_influxdb_rails_controller] = nil
-        Thread.current[:_influxdb_rails_action] = nil
-        Thread.current[:_influxdb_rails_tags] = nil
-        Thread.current[:_influxdb_rails_values] = nil
-        Thread.current[:_influxdb_rails_request_id] = nil
+        Thread.current[:_influxdb_rails_tags] = {}
+        Thread.current[:_influxdb_rails_values] = {}
       end
 
       def tags
-        Thread.current[:_influxdb_rails_tags] || {}
+        Thread.current[:_influxdb_rails_tags].to_h
       end
 
       def tags=(tags)
-        Thread.current[:_influxdb_rails_tags] = tags
+        Thread.current[:_influxdb_rails_tags] = self.tags.merge(tags)
       end
 
       def values
-        Thread.current[:_influxdb_rails_values].to_h.merge(request_id: request_id)
+        Thread.current[:_influxdb_rails_values].to_h
       end
 
       def values=(values)
-        Thread.current[:_influxdb_rails_values] = values
+        Thread.current[:_influxdb_rails_values] = self.values.merge(values)
       end
     end
   end

--- a/lib/influxdb/rails/middleware/sql_subscriber.rb
+++ b/lib/influxdb/rails/middleware/sql_subscriber.rb
@@ -25,6 +25,7 @@ module InfluxDB
             operation:  query.operation,
             class_name: query.class_name,
             name:       query.name,
+            location:   :raw,
           }
         end
       end

--- a/lib/influxdb/rails/railtie.rb
+++ b/lib/influxdb/rails/railtie.rb
@@ -12,14 +12,14 @@ module InfluxDB
         ActiveSupport.on_load(:action_controller) do
           before_action do
             current = InfluxDB::Rails.current
-            current.request_id = request.request_id if request.respond_to?(:request_id)
+            current.values = { request_id: request.request_id } if request.respond_to?(:request_id)
           end
         end
 
         cache = lambda do |_, _, _, _, payload|
           current = InfluxDB::Rails.current
-          current.controller = payload[:controller]
-          current.action     = payload[:action]
+          location = [payload[:controller], payload[:action]].join("#")
+          current.tags = { location: location }
         end
         ActiveSupport::Notifications.subscribe "start_processing.action_controller", &cache
 

--- a/lib/influxdb/rails/tags.rb
+++ b/lib/influxdb/rails/tags.rb
@@ -17,26 +17,14 @@ module InfluxDB
       attr_reader :tags, :config
 
       def expanded_tags
-        config.tags_middleware.call(default_tags.merge(tags))
+        config.tags_middleware.call(tags.merge(default_tags))
       end
 
       def default_tags
         {
           server:   Socket.gethostname,
           app_name: config.application_name,
-          location: location.presence || default_location,
         }.merge(InfluxDB::Rails.current.tags)
-      end
-
-      def location
-        [
-          current.controller,
-          current.action,
-        ].reject(&:blank?).join("#")
-      end
-
-      def default_location
-        :raw
       end
 
       def current


### PR DESCRIPTION
Current attributes are global variables so we should only
have a few. This PR removes all current attributes except values and tags
as the other attributes were anyway values or tags.

* request_id is a values
* controller and action were merged to location tag

There is a slight change in behaviour as we now merge the tags and value instead of overwritting but I think this is okay. Another approach could be that we leave the overwritting but fetch and set internally.

```ruby
# before
InfluxDB::Rails.current.values = { a: :a }
InfluxDB::Rails.current.values = { b: :b }

puts InfluxDB::Rails.current.values
# => { b: :b }

# after
InfluxDB::Rails.current.values = { a: :a }
InfluxDB::Rails.current.values = { b: :b }

puts InfluxDB::Rails.current.values
# => { a: :a, b: :b }
```

@hennevogel WDYT?