### PR TITLE
Disable ruby-head for Rails < 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ matrix:
   exclude:
     # Rails > 5 not on MRI 2.4+
     - { rvm: "2.4",   gemfile: "gemfiles/Gemfile.rails-6.0.x" }
+    - { rvm: "ruby-head",   gemfile: "gemfiles/Gemfile.rails-5.2.x" }
+    - { rvm: "ruby-head",   gemfile: "gemfiles/Gemfile.rails-5.1.x" }
+    - { rvm: "ruby-head",   gemfile: "gemfiles/Gemfile.rails-5.0.x" }
 addons:
   apt:
     packages:


### PR DESCRIPTION
ruby-head does fail with Rails version < 6.0. I reckon this is because of the kwargs changes. I think we can disable these specs.

![image](https://user-images.githubusercontent.com/3799140/81561830-bd118280-938b-11ea-9ed9-517a04728410.png)


```ruby
Loading Rails v5.2.4.2...
An error occurred while loading ./spec/requests/action_controller_metrics_spec.rb.
Failure/Error: app.initialize!
ArgumentError:
  wrong number of arguments (given 3, expected 2)
# /home/travis/.rvm/gems/ruby-head/gems/actionpack-5.2.4.2/lib/action_dispatch/middleware/static.rb:111:in `initialize'
# /home/travis/.rvm/gems/ruby-head/gems/actionpack-5.2.4.2/lib/action_dispatch/middleware/stack.rb:37:in `new'
# /home/travis/.rvm/gems/ruby-head/gems/actionpack-5.2.4.2/lib/action_dispatch/middleware/stack.rb:37:in `build'
# /home/travis/.rvm/gems/ruby-head/gems/actionpack-5.2.4.2/lib/action_dispatch/middleware/stack.rb:101:in `block in build'
# /home/travis/.rvm/gems/ruby-head/gems/actionpack-5.2.4.2/lib/action_dispatch/middleware/stack.rb:101:in `each'
# /home/travis/.rvm/gems/ruby-head/gems/actionpack-5.2.4.2/lib/action_dispatch/middleware/stack.rb:101:in `inject'
# /home/travis/.rvm/gems/ruby-head/gems/actionpack-5.2.4.2/lib/action_dispatch/middleware/stack.rb:101:in `build'
# /home/travis/.rvm/gems/ruby-head/gems/railties-5.2.4.2/lib/rails/engine.rb:510:in `block in app'
# /home/travis/.rvm/gems/ruby-head/gems/railties-5.2.4.2/lib/rails/engine.rb:506:in `synchronize'
# /home/travis/.rvm/gems/ruby-head/gems/railties-5.2.4.2/lib/rails/engine.rb:506:in `app'
# /home/travis/.rvm/gems/ruby-head/gems/railties-5.2.4.2/lib/rails/application/finisher.rb:47:in `block in <module:Finisher>'
# /home/travis/.rvm/gems/ruby-head/gems/railties-5.2.4.2/lib/rails/initializable.rb:32:in `instance_exec'
# /home/travis/.rvm/gems/ruby-head/gems/railties-5.2.4.2/lib/rails/initializable.rb:32:in `run'
# /home/travis/.rvm/gems/ruby-head/gems/railties-5.2.4.2/lib/rails/initializable.rb:61:in `block in run_initializers'
# /home/travis/.rvm/gems/ruby-head/gems/railties-5.2.4.2/lib/rails/initializable.rb:60:in `run_initializers'
# /home/travis/.rvm/gems/ruby-head/gems/railties-5.2.4.2/lib/rails/application.rb:361:in `initialize!'
# /home/travis/.rvm/gems/ruby-head/gems/railties-5.2.4.2/lib/rails/railtie.rb:190:in `public_send'
# /home/travis/.rvm/gems/ruby-head/gems/railties-5.2.4.2/lib/rails/railtie.rb:190:in `method_missing'
# ./spec/support/rails5/app.rb:14:in `<top (required)>'
# ./spec/spec_helper.rb:23:in `require'
# ./spec/spec_helper.rb:23:in `<top (required)>'
# ./spec/requests/action_controller_metrics_spec.rb:1:in `require'
# ./spec/requests/action_controller_metrics_spec.rb:1:in `<top (required)>'
```