### PR TITLE
Implement block instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For the full commit log, [see here](https://github.com/influxdata/influxdb-rails
 - Implement `enqueue.active_job` subscriber (https://guides.rubyonrails.org/active_support_instrumentation.html#enqueue-active-job)
 - Implement `perform_start.active_job` subscriber (https://guides.rubyonrails.org/active_support_instrumentation.html#perform-start-active-job)
 - Implement `perform.active_job` subscriber (https://guides.rubyonrails.org/active_support_instrumentation.html#perform-active-job)
+- Implement block instrumentation `InfluxDB::Rails.instrument do; 1 + 1; end`
 
 ## v1.0.0, released 2019-10-23
 The Final release, no code changes.

--- a/README.md
+++ b/README.md
@@ -176,6 +176,44 @@ class ApplicationController
 end
 ```
 
+### Block Instrumentation
+If you want to add custom instrumentation, you can wrap any code into a block instrumentation
+
+```ruby
+InfluxDB::Rails.instrument "expensive_operation", tags: { }, values: { } do
+  expensive_operation
+end
+```
+
+Reported tags:
+
+```ruby
+  hook:       "block_instrumentation"
+  server:     Socket.gethostname,
+  app_name:   configuration.application_name,
+  location:   "PostsController#index",
+  name:       "expensive_operation"
+```
+
+Reported values:
+```ruby
+  value: 100 # execution time of the block
+```
+
+You can also overwrite the `value`
+
+```ruby
+InfluxDB::Rails.instrument "user_count", values: { value: 1 } do
+  User.create(name: 'mickey', surname: 'mouse')
+end
+```
+
+or call it even without a block
+
+```ruby
+InfluxDB::Rails.instrument "temperature", values: { value: 25 }
+```
+
 ### Custom client configuration
 
 The settings named `config.client.*` are used to construct an `InfluxDB::Client`

--- a/lib/influxdb-rails.rb
+++ b/lib/influxdb-rails.rb
@@ -2,6 +2,7 @@ require "net/http"
 require "net/https"
 require "rubygems"
 require "socket"
+require "influxdb/rails/middleware/block_instrumentation_subscriber"
 require "influxdb/rails/middleware/render_subscriber"
 require "influxdb/rails/middleware/request_subscriber"
 require "influxdb/rails/middleware/sql_subscriber"
@@ -59,6 +60,13 @@ module InfluxDB
 
       def current
         @current ||= InfluxDB::Rails::Context.new
+      end
+
+      def instrument(name, options = {})
+        ActiveSupport::Notifications.instrument "block_instrumentation.influxdb_rails",
+                                                **options.merge(name: name) do
+          yield if block_given?
+        end
       end
     end
   end

--- a/lib/influxdb/rails/middleware/block_instrumentation_subscriber.rb
+++ b/lib/influxdb/rails/middleware/block_instrumentation_subscriber.rb
@@ -1,0 +1,22 @@
+require "influxdb/rails/middleware/subscriber"
+
+module InfluxDB
+  module Rails
+    module Middleware
+      class BlockInstrumentationSubscriber < Subscriber
+        def values(_start, duration, payload)
+          {
+            value: duration,
+          }.merge(payload[:values].to_h)
+        end
+
+        def tags(payload)
+          {
+            hook: "block_instrumentation",
+            name: payload[:name],
+          }.merge(payload[:tags].to_h)
+        end
+      end
+    end
+  end
+end

--- a/lib/influxdb/rails/railtie.rb
+++ b/lib/influxdb/rails/railtie.rb
@@ -25,15 +25,16 @@ module InfluxDB
         ActiveSupport::Notifications.subscribe "start_processing.action_controller", &cache
 
         {
-          "process_action.action_controller" => Middleware::RequestSubscriber,
-          "render_template.action_view"      => Middleware::RenderSubscriber,
-          "render_partial.action_view"       => Middleware::RenderSubscriber,
-          "render_collection.action_view"    => Middleware::RenderSubscriber,
-          "sql.active_record"                => Middleware::SqlSubscriber,
-          "instantiation.active_record"      => Middleware::ActiveRecordSubscriber,
-          "enqueue.active_job"               => Middleware::ActiveJobSubscriber,
-          "perform_start.active_job"         => Middleware::ActiveJobSubscriber,
-          "perform.active_job"               => Middleware::ActiveJobSubscriber,
+          "process_action.action_controller"     => Middleware::RequestSubscriber,
+          "render_template.action_view"          => Middleware::RenderSubscriber,
+          "render_partial.action_view"           => Middleware::RenderSubscriber,
+          "render_collection.action_view"        => Middleware::RenderSubscriber,
+          "sql.active_record"                    => Middleware::SqlSubscriber,
+          "instantiation.active_record"          => Middleware::ActiveRecordSubscriber,
+          "enqueue.active_job"                   => Middleware::ActiveJobSubscriber,
+          "perform_start.active_job"             => Middleware::ActiveJobSubscriber,
+          "perform.active_job"                   => Middleware::ActiveJobSubscriber,
+          "block_instrumentation.influxdb_rails" => Middleware::BlockInstrumentationSubscriber,
         }.each do |hook_name, subscriber_class|
           subscribe_to(hook_name, subscriber_class)
         end

--- a/spec/requests/block_inistrumentation_spec.rb
+++ b/spec/requests/block_inistrumentation_spec.rb
@@ -1,0 +1,64 @@
+require File.dirname(__FILE__) + "/../spec_helper"
+
+RSpec.describe "BlockInstrumentation metrics", type: :request do
+  let(:tags_middleware) do
+    lambda do |tags|
+      tags.merge(tags_middleware: :tags_middleware)
+    end
+  end
+  before do
+    allow_any_instance_of(ActionDispatch::Request).to receive(:request_id).and_return(:request_id)
+    allow_any_instance_of(InfluxDB::Rails::Configuration).to receive(:application_name).and_return(:app_name)
+    allow_any_instance_of(InfluxDB::Rails::Configuration).to receive(:tags_middleware).and_return(tags_middleware)
+  end
+
+  it "writes metric" do
+    get "/metrics"
+
+    expect_metric(
+      tags:   a_hash_including(
+        location:        "MetricsController#index",
+        hook:            "block_instrumentation",
+        additional_tag:  :value,
+        server:          Socket.gethostname,
+        app_name:        :app_name,
+        tags_middleware: :tags_middleware,
+        block_tag:       :block_tag,
+        name:            "name"
+      ),
+      values: a_hash_including(
+        additional_value: :value,
+        request_id:       :request_id,
+        block_value:      :block_value,
+        value:            be_between(1, 30)
+      )
+    )
+  end
+
+  it "includes correct timestamps" do
+    travel_to Time.zone.local(2018, 1, 1, 9, 0, 0)
+
+    get "/metrics"
+
+    expect_metric(
+      tags:      a_hash_including(
+        location: "MetricsController#index",
+        hook:     "block_instrumentation"
+      ),
+      timestamp: 1_514_797_200
+    )
+  end
+
+  it "does not write metric when hook is ignored" do
+    allow_any_instance_of(InfluxDB::Rails::Configuration).to receive(:ignored_hooks).and_return(["block_instrumentation.influxdb_rails"])
+
+    get "/metrics"
+
+    expect_no_metric(
+      tags: a_hash_including(
+        location: "MetricsController#index",
+        hook:     "block_instrumentation"
+      )
+    )
+  end
+end

--- a/spec/support/rails5/app.rb
+++ b/spec/support/rails5/app.rb
@@ -49,6 +49,9 @@ class MetricsController < ApplicationController
   end
 
   def index
+    InfluxDB::Rails.instrument "name", tags: { block_tag: :block_tag }, values: { block_value: :block_value } do
+      1 + 1
+    end
     MetricJob.perform_later
     Metric.create!(name: "name")
   end

--- a/spec/support/rails6/app.rb
+++ b/spec/support/rails6/app.rb
@@ -49,6 +49,9 @@ class MetricsController < ApplicationController
   end
 
   def index
+    InfluxDB::Rails.instrument "name", tags: { block_tag: :block_tag }, values: { block_value: :block_value } do
+      1 + 1
+    end
     MetricJob.perform_later
     Metric.create!(name: "name")
   end

--- a/spec/unit/block_instrumentation_spec.rb
+++ b/spec/unit/block_instrumentation_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+RSpec.describe InfluxDB::Rails do
+  describe ".instrument" do
+    it "supports calling wihout a block" do
+      InfluxDB::Rails.instrument "name", values: { value: 1 }
+
+      expect_metric(
+        values: a_hash_including(value: 1),
+        tags:   a_hash_including(
+          hook:     "block_instrumentation",
+          server:   Socket.gethostname,
+          location: :raw
+        )
+      )
+    end
+  end
+end


### PR DESCRIPTION
Implements a block instrumentation API

```ruby
InfluxDB::Rails.instrument "name", tags: { }, values: { } do
  1 + 1
end
```

https://github.com/influxdata/influxdb-rails/issues/108