### PR TITLE
Instantiate middleware

### DIFF
--- a/lib/influxdb/rails/metric.rb
+++ b/lib/influxdb/rails/metric.rb
@@ -4,23 +4,20 @@ require "influxdb/rails/tags"
 module InfluxDB
   module Rails
     class Metric
-      def initialize(configuration:, timestamp:, tags: {}, values: {}, hook_name:)
+      def initialize(configuration:, timestamp:, tags: {}, values: {})
         @configuration = configuration
         @timestamp = timestamp
         @tags = tags
         @values = values
-        @hook_name = hook_name
       end
 
       def write
-        return unless enabled?
-
         client.write_point configuration.measurement_name, options
       end
 
       private
 
-      attr_reader :configuration, :tags, :values, :timestamp, :hook_name
+      attr_reader :configuration, :tags, :values, :timestamp
 
       def options
         {
@@ -32,11 +29,6 @@ module InfluxDB
 
       def timestamp_with_precision
         InfluxDB.convert_timestamp(timestamp.utc, configuration.client.time_precision)
-      end
-
-      def enabled?
-        !configuration.ignore_current_environment? &&
-          !configuration.ignored_hooks.include?(hook_name)
       end
 
       def client

--- a/lib/influxdb/rails/middleware/active_record_subscriber.rb
+++ b/lib/influxdb/rails/middleware/active_record_subscriber.rb
@@ -7,14 +7,14 @@ module InfluxDB
       class ActiveRecordSubscriber < Subscriber # :nodoc:
         private
 
-        def values(_start, duration, payload)
+        def values
           {
             value:        duration,
             record_count: payload[:record_count],
           }
         end
 
-        def tags(payload)
+        def tags
           {
             hook:       "instantiation",
             class_name: payload[:class_name],

--- a/lib/influxdb/rails/middleware/block_instrumentation_subscriber.rb
+++ b/lib/influxdb/rails/middleware/block_instrumentation_subscriber.rb
@@ -4,13 +4,15 @@ module InfluxDB
   module Rails
     module Middleware
       class BlockInstrumentationSubscriber < Subscriber
-        def values(_start, duration, payload)
+        private
+
+        def values
           {
             value: duration,
           }.merge(payload[:values].to_h)
         end
 
-        def tags(payload)
+        def tags
           {
             hook: "block_instrumentation",
             name: payload[:name],

--- a/lib/influxdb/rails/middleware/render_subscriber.rb
+++ b/lib/influxdb/rails/middleware/render_subscriber.rb
@@ -4,15 +4,9 @@ module InfluxDB
   module Rails
     module Middleware
       class RenderSubscriber < Subscriber # :nodoc:
-        def short_hook_name
-          return "render_template" if hook_name.include?("render_template")
-          return "render_partial" if hook_name.include?("render_partial")
-          return "render_collection" if hook_name.include?("render_collection")
-        end
-
         private
 
-        def values(_start, duration, payload)
+        def values
           {
             value:      duration,
             count:      payload[:count],
@@ -20,11 +14,17 @@ module InfluxDB
           }
         end
 
-        def tags(payload)
+        def tags
           {
             hook:     short_hook_name,
             filename: payload[:identifier],
           }
+        end
+
+        def short_hook_name
+          return "render_template" if hook_name.include?("render_template")
+          return "render_partial" if hook_name.include?("render_partial")
+          return "render_collection" if hook_name.include?("render_collection")
         end
       end
     end

--- a/lib/influxdb/rails/middleware/request_subscriber.rb
+++ b/lib/influxdb/rails/middleware/request_subscriber.rb
@@ -4,7 +4,7 @@ module InfluxDB
   module Rails
     module Middleware
       class RequestSubscriber < Subscriber # :nodoc:
-        def call(_name, started, finished, _unique_id, payload)
+        def write
           super
         ensure
           InfluxDB::Rails.current.reset
@@ -12,7 +12,7 @@ module InfluxDB
 
         private
 
-        def tags(payload)
+        def tags
           {
             method:      "#{payload[:controller]}##{payload[:action]}",
             hook:        "process_action",
@@ -22,16 +22,20 @@ module InfluxDB
           }
         end
 
-        def values(start, duration, payload)
+        def values
           {
             controller: duration,
             view:       (payload[:view_runtime] || 0).ceil,
             db:         (payload[:db_runtime] || 0).ceil,
-            started:    InfluxDB.convert_timestamp(
-              start.utc,
-              configuration.client.time_precision
-            ),
+            started:    started,
           }
+        end
+
+        def started
+          InfluxDB.convert_timestamp(
+            start.utc,
+            configuration.client.time_precision
+          )
         end
       end
     end

--- a/lib/influxdb/rails/middleware/subscriber.rb
+++ b/lib/influxdb/rails/middleware/subscriber.rb
@@ -7,38 +7,60 @@ module InfluxDB
       # which are intended as ActiveSupport::Notifications.subscribe
       # consumers.
       class Subscriber
-        attr_reader :configuration
-        attr_reader :hook_name
-
-        def initialize(configuration, hook_name)
+        def initialize(configuration:, hook_name:, start:, finish:, payload:)
           @configuration = configuration
           @hook_name = hook_name
+          @start = start
+          @finish = finish
+          @payload = payload
         end
 
-        def call(_name, start, finish, _id, payload)
-          write_metric(start, finish, payload)
+        def self.call(name, start, finish, _id, payload)
+          new(
+            configuration: InfluxDB::Rails.configuration,
+            start:         start,
+            finish:        finish,
+            payload:       payload,
+            hook_name:     name
+          ).write
+        end
+
+        def write
+          return if disabled?
+
+          metric.write
         rescue StandardError => e
           ::Rails.logger.error("[InfluxDB::Rails] Unable to write points: #{e.message}")
         end
 
         private
 
-        def write_metric(start, finish, payload)
+        attr_reader :configuration, :hook_name, :start, :finish, :payload
+
+        def metric
           InfluxDB::Rails::Metric.new(
-            values:        values(start, ((finish - start) * 1000).ceil, payload),
-            tags:          tags(payload),
+            values:        values,
+            tags:          tags,
             configuration: configuration,
-            timestamp:     finish,
-            hook_name:     hook_name
-          ).write
+            timestamp:     finish
+          )
         end
 
-        def tags(*)
+        def tags
           raise NotImplementedError, "must be implemented in subclass"
         end
 
-        def values(*)
+        def values
           raise NotImplementedError, "must be implemented in subclass"
+        end
+
+        def duration
+          ((finish - start) * 1000).ceil
+        end
+
+        def disabled?
+          configuration.ignore_current_environment? ||
+            configuration.ignored_hooks.include?(hook_name)
         end
       end
     end

--- a/lib/influxdb/rails/railtie.rb
+++ b/lib/influxdb/rails/railtie.rb
@@ -35,16 +35,11 @@ module InfluxDB
           "perform_start.active_job"             => Middleware::ActiveJobSubscriber,
           "perform.active_job"                   => Middleware::ActiveJobSubscriber,
           "block_instrumentation.influxdb_rails" => Middleware::BlockInstrumentationSubscriber,
-        }.each do |hook_name, subscriber_class|
-          subscribe_to(hook_name, subscriber_class)
+        }.each do |hook_name, subscriber|
+          ActiveSupport::Notifications.subscribe(hook_name, subscriber)
         end
       end
       # rubocop:enable Metrics/BlockLength
-
-      def subscribe_to(hook_name, subscriber_class)
-        subscriber = subscriber_class.new(InfluxDB::Rails.configuration, hook_name)
-        ActiveSupport::Notifications.subscribe hook_name, subscriber
-      end
     end
   end
 end

--- a/lib/influxdb/rails/tags.rb
+++ b/lib/influxdb/rails/tags.rb
@@ -1,9 +1,10 @@
 module InfluxDB
   module Rails
     class Tags
-      def initialize(tags: {}, config:)
+      def initialize(tags: {}, config:, additional_tags: InfluxDB::Rails.current.tags)
         @tags = tags
         @config = config
+        @additional_tags = additional_tags
       end
 
       def to_h
@@ -14,7 +15,7 @@ module InfluxDB
 
       private
 
-      attr_reader :tags, :config
+      attr_reader :additional_tags, :tags, :config
 
       def expanded_tags
         config.tags_middleware.call(tags.merge(default_tags))
@@ -25,11 +26,7 @@ module InfluxDB
           server:   Socket.gethostname,
           app_name: config.application_name,
           location: :raw,
-        }.merge(InfluxDB::Rails.current.tags)
-      end
-
-      def current
-        @current ||= InfluxDB::Rails.current
+        }.merge(additional_tags)
       end
     end
   end

--- a/lib/influxdb/rails/values.rb
+++ b/lib/influxdb/rails/values.rb
@@ -1,8 +1,9 @@
 module InfluxDB
   module Rails
     class Values
-      def initialize(values: {})
+      def initialize(values: {}, additional_values: InfluxDB::Rails.current.values)
         @values = values
+        @additional_values = additional_values
       end
 
       def to_h
@@ -13,14 +14,10 @@ module InfluxDB
 
       private
 
-      attr_reader :values
+      attr_reader :additional_values, :values
 
       def expanded_values
         values.merge(additional_values)
-      end
-
-      def additional_values
-        InfluxDB::Rails.current.values
       end
     end
   end


### PR DESCRIPTION
So far we only created one instance of the middleware and then operated on this instance. This made the code quite ugly because we always needed to pass around the method parameters from method to method. This PR creates now a new instance for each request.

The main part what I changed is basically from

```ruby
class Subscriber
  def call(name, start, finish, payload)
  end
end
```

to

```ruby
class Subscriber
  def self.call(name, start, finish, payload)
    new(name, start, finish, payload)
  end
end
```

which resulted that we basically dropped all method parameters from all functions. In my opinion this makes the code a lot nicer to work with because we can easily extract helper methods and memoize values. This refactoring is a preparation for https://github.com/influxdata/influxdb-rails/issues/117 which made it quite hard to squeeze more code without the ability to have helper methods.

Downside of this approach is of course that we create a few more instances per request but I think this is worth it.