### PR TITLE
Record exception class name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For the full commit log, [see here](https://github.com/influxdata/influxdb-rails
 - Implement `perform_start.active_job` subscriber (https://guides.rubyonrails.org/active_support_instrumentation.html#perform-start-active-job)
 - Implement `perform.active_job` subscriber (https://guides.rubyonrails.org/active_support_instrumentation.html#perform-active-job)
 - Implement block instrumentation `InfluxDB::Rails.instrument do; 1 + 1; end`
+- Record unhandled exceptions as tags for process_action.action_controller
 
 ## v1.0.0, released 2019-10-23
 The Final release, no code changes.

--- a/README.md
+++ b/README.md
@@ -71,9 +71,14 @@ Reported tags:
   method:      "PostsController#index",
   http_method: "GET",
   format:      "html",
-  status:      "200"
+  status:      ["200", ""]
+  exception:   ["", "ArgumentError"]
 }
 ```
+
+*Note*: If an exception happens during that particular instrumentation the
+`status` will be blank and the tag `exception` will contain the name of the
+exception class.
 
 ### Action View
 

--- a/lib/influxdb/rails/middleware/request_subscriber.rb
+++ b/lib/influxdb/rails/middleware/request_subscriber.rb
@@ -19,6 +19,7 @@ module InfluxDB
             status:      payload[:status],
             format:      payload[:format],
             http_method: payload[:method],
+            exception:   payload[:exception]&.first,
           }
         end
 

--- a/spec/requests/action_controller_metrics_spec.rb
+++ b/spec/requests/action_controller_metrics_spec.rb
@@ -74,8 +74,9 @@ RSpec.describe "ActionController metrics", type: :request do
 
     expect_metric(
       tags: a_hash_including(
-        method: "ExceptionsController#index",
-        hook:   "process_action"
+        method:    "ExceptionsController#index",
+        hook:      "process_action",
+        exception: "ZeroDivisionError"
       )
     )
   end


### PR DESCRIPTION
If an exception happens during instrumentation with ActiveSupport the
payload will have a key :exception.

Report the exception class name as tag. Will make it possible to measure
"potential" problems. Potential as we don't know if the exception will
be handled higher up in the call chain.