### PR TITLE
Make use_ssl configuration option more discoverable

### DIFF
--- a/lib/rails/generators/influxdb/templates/initializer.rb
+++ b/lib/rails/generators/influxdb/templates/initializer.rb
@@ -11,6 +11,10 @@ InfluxDB::Rails.configure do |config|
   # config.client.username = "root"
   # config.client.password = "root"
 
+  ## If your InfluxDB service requires an HTTPS connection then you can
+  ## enable it here.
+  # config.client.use_ssl = true
+
   ## Various other client and connection options. These are used to create
   ## an `InfluxDB::Client` instance (i.e. `InfluxDB::Rails.client`).
   ##


### PR DESCRIPTION
The InfluxDB docs encourage encrypting the connection between client and server but by default client.use_ssl is set to false. To aid developer discoverability we can include the option in the initializer template.

This should help address understandable confusion as in https://github.com/influxdata/influxdb-rails/issues/153.