### PR TITLE
We stopped testing on 2.4 a while ago

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,8 @@ AllCops:
   - 'vendor/bundle/**/*'
   DisplayCopNames: true
   StyleGuideCopsOnly: false
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
+  NewCops: enable
 
 Layout/EmptyLinesAroundArguments:
   Enabled: false

--- a/influxdb-rails.gemspec
+++ b/influxdb-rails.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features|smoke)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_ruby_version = ">= 2.5.0"
 
   spec.add_runtime_dependency "influxdb", "~> 0.6", ">= 0.6.4"
   spec.add_runtime_dependency "railties", ">= 5.0"


### PR DESCRIPTION
Now rubocop also dropped support for 2.4, let's require 2.5.