### PR TITLE
Update 'Requests per...' panel in Performance Dashboard

### DIFF
--- a/sample-dashboard/Ruby On Rails Performance.json
+++ b/sample-dashboard/Ruby On Rails Performance.json
@@ -634,7 +634,8 @@
     {
       "aliasColors": {
         "Error": "dark-red",
-        "Success": "semi-dark-green"
+        "Success": "semi-dark-green",
+        "No Status": "#bebebe"
       },
       "bars": true,
       "dashLength": 10,
@@ -677,7 +678,7 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
@@ -688,12 +689,6 @@
                 "$per"
               ],
               "type": "time"
-            },
-            {
-              "params": [
-                "previous"
-              ],
-              "type": "fill"
             }
           ],
           "measurement": "rails",
@@ -726,6 +721,12 @@
               "key": "status",
               "operator": "=",
               "value": "200"
+            },
+            {
+              "condition": "OR",
+              "key": "status",
+              "operator": "=",
+              "value": "302"
             }
           ]
         },
@@ -737,17 +738,13 @@
                 "$per"
               ],
               "type": "time"
-            },
-            {
-              "params": [
-                "previous"
-              ],
-              "type": "fill"
             }
           ],
           "measurement": "rails",
           "orderByTime": "ASC",
           "policy": "default",
+          "query": "SELECT count(\"controller\") FROM \"rails\" WHERE (\"hook\" = 'process_action' AND \"status\" != '200' AND \"status\" != '302' AND \"status\" != '') AND $timeFilter GROUP BY time($per)",
+          "rawQuery": true,
           "refId": "B",
           "resultFormat": "time_series",
           "select": [
@@ -775,6 +772,64 @@
               "key": "status",
               "operator": "!=",
               "value": "200"
+            },
+            {
+              "condition": "AND",
+              "key": "status",
+              "operator": "!=",
+              "value": "302"
+            },
+            {
+              "condition": "AND",
+              "key": "status",
+              "operator": "!=",
+              "value": ""
+            }
+          ]
+        },
+        {
+          "alias": "No Status",
+          "groupBy": [
+            {
+              "params": [
+                "$per"
+              ],
+              "type": "time"
+            }
+          ],
+          "hide": false,
+          "measurement": "rails",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT count(\"controller\") FROM \"rails\" WHERE (\"hook\" = 'process_action' AND \"status\" = '') AND $timeFilter GROUP BY time($per)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "controller"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "count"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "hook",
+              "operator": "=",
+              "value": "process_action"
+            },
+            {
+              "condition": "AND",
+              "key": "status",
+              "operator": "=",
+              "value": ""
             }
           ]
         }


### PR DESCRIPTION
- Count redirect status '302' as 'Success'
- 'No Status': Display entries without a status separately with a neutral grey
- Bars are now stacked
- Remove 'fill(previous)'


Fixes #188 

![Screen Shot Panel](https://user-images.githubusercontent.com/1899691/144308371-310d2bc3-b7d3-4541-8699-815f75fdbaf5.png)
