### PR TITLE
Fix tags middleware parsing

### DIFF
--- a/lib/influxdb/rails/configuration.rb
+++ b/lib/influxdb/rails/configuration.rb
@@ -67,7 +67,11 @@ module InfluxDB
       set_defaults(
         measurement_name:     "rails".freeze,
         ignored_hooks:        [].freeze,
-        tags_middleware:      ->(tags) { tags },
+        tags_middleware:      lambda { |tags|
+                                tags.reject do |_key, value|
+                                  value.nil? || (value.is_a?(String) && value.squish.empty?)
+                                end
+                              },
         rails_app_name:       nil,
         ignored_environments: %w[test cucumber selenium].freeze,
         environment:          ::Rails.env,

--- a/spec/unit/influx_db/rails/tags_spec.rb
+++ b/spec/unit/influx_db/rails/tags_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe InfluxDB::Rails::Tags do
 
     it "removes empty strings" do
       subject = described_class.new(config: config, tags: { hans: "", franz: "   " })
-      expect(subject.to_h).not_to a_hash_including(hans: "", franz: "   ")
+      expect(subject.to_h).not_to a_hash_including(:hans, :franz)
     end
 
     it "returns symbols" do
@@ -36,7 +36,7 @@ RSpec.describe InfluxDB::Rails::Tags do
 
     it "removes nil" do
       subject = described_class.new(config: config, tags: { hans: nil })
-      expect(subject.to_h).not_to a_hash_including(hans: nil)
+      expect(subject.to_h).not_to a_hash_including(:hans)
     end
 
     it "leaves arrays alone" do


### PR DESCRIPTION
Don't include key-value hash elements which:
- are only a sequence of empty strings
- are nil

Reintroduce tags spec.